### PR TITLE
Enable cover-art from metadata.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "configstore": "^4.0.0",
     "deep-equal": "^1.0.1",
     "electron-updater": "4.2.0",
+    "fs-extra": "^8.1.0",
     "fuse.js": "3.4.6",
     "lokijs": "1.5.8",
     "music-metadata": "5.0.1",
@@ -22,7 +23,8 @@
     "react-lazy-load": "^3.0.13",
     "react-router-dom": "5.1.2",
     "react-scripts": "3.2.0",
-    "react-table": "6.10.3"
+    "react-table": "6.10.3",
+    "uuid": "^3.4.0"
   },
   "main": "public/electron.js",
   "homepage": "./",

--- a/src/components/detail/Detail.js
+++ b/src/components/detail/Detail.js
@@ -145,7 +145,7 @@ export default withRouter(withPlayer(class Detail extends Component {
 		const totalSize = data.map( track => track.size).reduce((a,v) => a + v, 0);
 		const totalLength = data.map( track => track.meta ? track.meta.format.duration : 0).reduce((a,v) => a + v, 0);
 
-		const chapters = this.chapterService ? this.chapterService.chapters : [];
+		const chapters = (this.chapterService && this.chapterService.chapters) ? this.chapterService.chapters : [];
 
 		const widths = this.hasArtwork ? '25%' : '33%';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11126,6 +11126,11 @@ uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
+uuid@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
 v8-compile-cache@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"


### PR DESCRIPTION
Enable cover-art from metadata:
- Cache cover-art, extracted from metadata,  in application data folder
- Clear cached cover-art files upon scan

Introducing new dependencies:
- [fs-extra](https://github.com/jprichardson/node-fs-extra), for promise based file-system operations
- [uuid](https://www.npmjs.com/package/uuid), for generating unique file names

